### PR TITLE
Call `__gcov_flush` immediately before `std::abort`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(CMAKE_CXX_STANDARD 17)
 message("CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
 
 if (ENEK_ENABLE_COVERAGE)
+  add_definitions(-DENEK_ENABLE_COVERAGE)
   add_compile_options("-coverage")
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -coverage")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -coverage")

--- a/src/util/assert.cpp
+++ b/src/util/assert.cpp
@@ -7,6 +7,11 @@
 #include <utility>
 #include <cstdlib>
 
+
+#if defined(ENEK_ENABLE_COVERAGE)
+extern "C" void __gcov_flush();
+#endif // defined(ENEK_ENABLE_COVERAGE)
+
 namespace Enek::Detail{
 
 AbortMessenger::AbortMessenger(char const *function_name,
@@ -62,6 +67,9 @@ AbortMessenger::~AbortMessenger()
     std::cerr << "Backtrace:\n" << stacktrace_ << '\n';
   }
   std::cerr << std::flush;
+#if defined(ENEK_ENABLE_COVERAGE)
+  __gcov_flush();
+#endif // defined(ENEK_ENABLE_COVERAGE)
   std::abort();
 }
 

--- a/src/util/assert.cpp
+++ b/src/util/assert.cpp
@@ -64,13 +64,14 @@ AbortMessenger::~AbortMessenger()
     std::cerr << "Git commit hash: " << git_commit_hash_ << '\n';
   }
   if (stacktrace_) {
-    std::cerr << "Backtrace:\n" << stacktrace_ << '\n';
+    std::cerr << "Backtrace:\n" << stacktrace_;
   }
   std::cerr << std::flush;
 #if defined(ENEK_ENABLE_COVERAGE)
-  __gcov_flush();
-#endif // defined(ENEK_ENABLE_COVERAGE)
+  __gcov_flush(); std::abort();
+#else // defined(ENEK_ENABLE_COVERAGE)
   std::abort();
+#endif // defined(ENEK_ENABLE_COVERAGE)
 }
 
 } // namespace Enek::Detail

--- a/src/util/throw.cpp
+++ b/src/util/throw.cpp
@@ -20,9 +20,10 @@ namespace Enek::Detail{
   std::exception_ptr const p = std::current_exception();
   if (!p) {
 #if defined(ENEK_ENABLE_COVERAGE)
-    __gcov_flush();
-#endif // defined(ENEK_ENABLE_COVERAGE)
+    __gcov_flush(); std::abort();
+#else // defined(ENEK_ENABLE_COVERAGE)
     std::abort();
+#endif // defined(ENEK_ENABLE_COVERAGE)
   }
   try {
     std::rethrow_exception(p);
@@ -53,15 +54,16 @@ namespace Enek::Detail{
           = boost::get_error_info<Enek::StackTraceErrorInfo>(e)) {
       if (p->size() != 0) {
         std::cerr << "Backtrace:\n";
-        std::cerr << *p << '\n';
+        std::cerr << *p;
       }
     }
     std::cerr << std::flush;
   }
 #if defined(ENEK_ENABLE_COVERAGE)
-  __gcov_flush();
-#endif // defined(ENEK_ENABLE_COVERAGE)
+  __gcov_flush(); std::abort();
+#else // defined(ENEK_ENABLE_COVERAGE)
   std::abort();
+#endif // defined(ENEK_ENABLE_COVERAGE)
 }
 
 TerminateHandlerSetter::TerminateHandlerSetter() noexcept

--- a/src/util/throw.cpp
+++ b/src/util/throw.cpp
@@ -9,12 +9,19 @@
 #include <cstdlib>
 
 
+#if defined(ENEK_ENABLE_COVERAGE)
+extern "C" void __gcov_flush();
+#endif // defined(ENEK_ENABLE_COVERAGE)
+
 namespace Enek::Detail{
 
 [[noreturn]] void TerminateHandlerSetter::terminate_handler_() noexcept
 {
   std::exception_ptr const p = std::current_exception();
   if (!p) {
+#if defined(ENEK_ENABLE_COVERAGE)
+    __gcov_flush();
+#endif // defined(ENEK_ENABLE_COVERAGE)
     std::abort();
   }
   try {
@@ -51,6 +58,9 @@ namespace Enek::Detail{
     }
     std::cerr << std::flush;
   }
+#if defined(ENEK_ENABLE_COVERAGE)
+  __gcov_flush();
+#endif // defined(ENEK_ENABLE_COVERAGE)
   std::abort();
 }
 

--- a/test/unit/util/assert.cpp
+++ b/test/unit/util/assert.cpp
@@ -11,8 +11,8 @@ TEST(UtilAssertTest, testWithoutMessage)
 {
   static_assert(SIGABRT == 6);
 #if defined(ENEK_ENABLE_ASSERT)
-  ASSERT_EXIT(ENEK_ASSERT(false);,
-              [](int exit_code) { return exit_code == 128 + SIGABRT; },
+  EXPECT_EXIT(ENEK_ASSERT(false);,
+              ::testing::KilledBySignal(SIGABRT),
               R"(assert\.cpp:18: .+: Assertion `false' failed\.
 (Git commit hash: |Backtrace:
 ))");
@@ -24,8 +24,8 @@ TEST(UtilAssertTest, testWithoutMessage)
 TEST(UtilAssertTest, testMessage)
 {
 #if defined(ENEK_ENABLE_ASSERT)
-  ASSERT_EXIT(ENEK_ASSERT(false) << "Death message.";,
-              [](int exit_code) { return exit_code == 128 + SIGABRT; },
+  EXPECT_EXIT(ENEK_ASSERT(false) << "Death message.";,
+              ::testing::KilledBySignal(SIGABRT),
               R"(assert\.cpp:32: .+: Assertion `false' failed\.
 Death message\.
 (Git commit hash: |Backtrace:
@@ -38,9 +38,9 @@ Death message\.
 TEST(UtilAssertTest, testOStreamManipulator)
 {
 #if defined(ENEK_ENABLE_ASSERT)
-  ASSERT_EXIT(ENEK_ASSERT(false) << "First line." << std::endl
+  EXPECT_EXIT(ENEK_ASSERT(false) << "First line." << std::endl
               << "Second line.";,
-              [](int exit_code) { return exit_code == 128 + SIGABRT; },
+              ::testing::KilledBySignal(SIGABRT),
               R"(assert\.cpp:48: .+: Assertion `false' failed\.
 First line.
 Second line.
@@ -66,8 +66,8 @@ std::ios &getMessage(std::ios &ios)
 TEST(UtilAssertTest, testIosManipulator)
 {
 #if defined(ENEK_ENABLE_ASSERT)
-  ASSERT_EXIT(ENEK_ASSERT(false) << getMessage;,
-              [](int exit_code) { return exit_code == 128 + SIGABRT; },
+  EXPECT_EXIT(ENEK_ASSERT(false) << getMessage;,
+              ::testing::KilledBySignal(SIGABRT),
               R"(assert\.cpp:74: .+: Assertion `false' failed.
 `std::ios' manipulator\.
 (Git commit hash: |Backtrace:
@@ -80,8 +80,8 @@ TEST(UtilAssertTest, testIosManipulator)
 TEST(UtilAssertTest, testIosBaseManipulator)
 {
 #if defined(ENEK_ENABLE_ASSERT)
-  ASSERT_EXIT(ENEK_ASSERT(false) << std::boolalpha << false;,
-              [](int exit_code) { return exit_code == 128 + SIGABRT; },
+  EXPECT_EXIT(ENEK_ASSERT(false) << std::boolalpha << false;,
+              ::testing::KilledBySignal(SIGABRT),
               R"(assert\.cpp:88: .+: Assertion `false' failed.
 false
 (Git commit hash: |Backtrace:

--- a/test/unit/util/throw.cpp
+++ b/test/unit/util/throw.cpp
@@ -116,7 +116,7 @@ TEST(UtilThrowTest, testMessage)
 TEST(UtilThrowTest, testTerminateWithoutMessage)
 {
   EXPECT_EXIT([]() noexcept { ENEK_THROW(std::runtime_error); }();,
-              [](int exit_code) { return exit_code == 128 + SIGABRT; },
+              ::testing::KilledBySignal(SIGABRT),
               R"(^`std::terminate' is called after throwing an instance of `.+'\.
 .*throw\.cpp:123: .*UtilThrowTest.*testTerminateWithoutMessage.*: 
 (Git commit hash: |Backtrace:
@@ -127,7 +127,7 @@ TEST(UtilThrowTest, testTerminate)
 {
   EXPECT_EXIT(
     []() noexcept { ENEK_THROW(std::runtime_error) << "An error message."; }();,
-    [](int exit_code) { return exit_code == 128 + SIGABRT; },
+    ::testing::KilledBySignal(SIGABRT),
     R"(^`std::terminate' is called after throwing an instance of `.+'\.
 .*throw\.cpp:134: .*UtilThrowTest.*testTerminate.*: An error message.
 (Git commit hash: |Backtrace:


### PR DESCRIPTION
If a program that is instrumented for coverage analysis by Gcov is terminated
by `std::abort()`, coverage data for code immediately before the call of
`std::abrot` is lost. An explicit call of `__gcov_flush` immediately before the
call of `std::abort` prevents coverage data from being lost.